### PR TITLE
Set up `tagref` checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,7 @@ jobs:
           command: build
       - name: test
         run: cargo test
+      - name: Tag checking
+        run: |
+          curl https://raw.githubusercontent.com/stepchowfun/tagref/main/install.sh -LSfs | sh
+          tagref

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -302,7 +302,7 @@ fn rewrites_simple_binders() {
     );
 }
 
-/* Note [Query Plan Structure]
+/* [tag:query_plan_structure]
 
 This module builds a query plan that nests queries for relational values in an
 efficient order for evaluation.  As an example, if a query selects:


### PR DESCRIPTION
The `tagref` tool checks that comment-level crossreferences are consistent. There aren't any in the codebase yet, but there will be shortly.  This sets up the CI infrastructure.