### PR TITLE
Add a `Callable.hasParseError` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ The supported CodeQL objects and methods are documented in [a file](doc/library.
 
 # Roadmap
 
+`ql-grep` is in a very early prototype stage.  There will be rough edges and many missing features.
+
+- It is currently primarily a command line tool
+- There is a library interface, but it is poorly thought-out and incomplete (requests welcome)
+
 ## 1.0
 
 This will be the initial release with a focus on largely syntactic and local queries.  Planned supported languages include:

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,40 @@
+This document contains notes for ql-grep developers.
+
+# General
+
+- Note the design goals in the README
+- This project uses GHC-style documentation cross-references and uses [tagref](https://github.com/stepchowfun/tagref) to ensure that they remain consistent
+- You may want to prefer release builds, as debug builds generate enormous (> 700MB) binaries
+
+# Adding Support for new CodeQL Methods
+
+The process for adding a new method to an existing type is as follows:
+
+1. Add the method to [the library](./library.kdl)
+2. Implement a Rust function in [method_library.rs](../src/compile/method_library.rs) that is evaluated at run-time
+  - If necessary (e.g., if the feature requires additional tree-sitter queries), implement the language-specific queries in the `TreeInterface` (`[ref:tree_interface_definition]`).  This requires adding a new method to the interface and providing implementations for each supported language.
+3. Add the method to the `METHOD_IMPLS` map (see `[ref:method_impls_map]`) in [method_library.rs](../src/compile/method_library.rs)
+4. Add tests to the integration test suite
+  - Add at least one toml test description in the integration test [expected results directory](../tests/integration)
+  - They can refer to codebases in the [features](../tests/codebases/feature) directory (you can re-use existing feature-oriented test codebases, but it is better to add new targeted ones as-needed)
+
+Note that the type checker is driven by the definitions in the library and most of the rest of the pipeline is generic enough that most new methods will not require additional changes.
+
+# Adding Support for a new Programming Language
+
+If your desired language already has a tree-sitter grammar:
+
+1. Add the tree-sitter grammar for your language by either:
+   - Making the crates.io package a dependency in the [Cargo.toml](../Cargo.toml) file or, or
+   - Adding the grammar as a git submodule under the [third-party](../third-party) directory and making sure that it is built by [build.rs](../build.rs)
+2. Add an enumeration value to the `Language` enumeration in [source_file.rs](../src/source_file.rs) (`[ref:language_enum_definition]`)
+3. Add an entry to the `LANGUAGES` map in the same file, mapping the supported file extensions to the associated tree-sitter parser
+4. Define a new type to implement the tree-sitter adapter for your language in a new file in the [backends](../src/compile/backend) directory and implement the `TreeInterface` trait for it
+5. Export your new module from [backend.rs](../src/compile/backend.rs)
+6. Add a case for your language to the `make_tree_interface` function in [compile.rs](../src/compile.rs) (see `[ref:tree_sitter_interface_dispatcher]`) to instantiate your new tree-sitter adapter
+
+If your desired language does not already have a tree-sitter grammar, write one and then follow the instructions above.
+
+# Adding Support for a new CodeQL Type
+
+(This case is a lot more complex)

--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -23,6 +23,8 @@ type "Function" {
     method "getName" type="string" tag="[tag:library:Function:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
+    method "hasParseError" type="boolean" tag="[tag:library:Function:hasParseError]" \
+        docstring=r"Returns True if the function contains a parse error"
 }
 
 type "Method" {
@@ -37,6 +39,8 @@ type "Method" {
     method "getName" type="string" tag="[tag:library:Method:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
+    method "hasParseError" type="boolean" tag="[tag:library:Method:hasParseError]" \
+        docstring=r"Returns True if the method contains a parse error"
 }
 
 type "Callable" {
@@ -51,6 +55,8 @@ type "Callable" {
     method "getName" type="string" tag="[tag:library:Callable:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
+    method "hasParseError" type="boolean" tag="[tag:library:Callable:hasParseError]" \
+        docstring=r"Returns True if the callable contains a parse error"
 }
 
 // Parameters are *formal* parameters of function definitions/declarations

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -53,6 +53,10 @@ impl Context {
     }
 }
 
+/// Examine the given source file and determine which tree-sitter adapter to use
+/// while processing it.
+///
+/// [tag:tree_sitter_interface_dispatcher]
 fn make_tree_interface(file: &SourceFile) -> Rc<dyn TreeInterface> {
     match file.lang {
         Language::CPP => Rc::new(CPPTreeInterface::new(file)) as Rc<dyn TreeInterface>,
@@ -118,9 +122,7 @@ fn compile_var_ref(var_name: &str, var_type: &Type) -> anyhow::Result<NodeFilter
         }
         ty => {
             let msg = format!("References to variables of type `{ty}` are not yet supported");
-            Err(anyhow::anyhow!(PlanError::GeneralUnsupported(
-                msg.to_string()
-            )))
+            Err(anyhow::anyhow!(PlanError::GeneralUnsupported(msg)))
         }
     }
 }
@@ -499,6 +501,8 @@ pub fn compile_query<'a>(
                 .get(var)
                 .ok_or_else(|| anyhow::anyhow!(PlanError::UndeclaredVariable(var.into())))?;
             let unsupported = PlanError::UnsupportedTypeForLanguage(ty.clone(), source.lang);
+            // NOTE: If the top-level selected type is not supported, the query
+            // is just not compiled for this file
             let top_level = tree_interface
                 .top_level_type(ty)
                 .ok_or_else(|| anyhow::anyhow!(unsupported))?;

--- a/src/compile/interface.rs
+++ b/src/compile/interface.rs
@@ -168,6 +168,8 @@ pub struct FormalArgument {
 ///
 /// In cases where structure is sufficiently uniform, we should use normal
 /// functions instead.
+///
+/// [tag:tree_interface_definition]
 pub trait TreeInterface {
     /// Return a matcher for a type declared in the From clause of a QL query
     ///
@@ -187,4 +189,8 @@ pub trait TreeInterface {
     /// This is tailored to just callables because getting the name of other
     /// types of nodes requires different patterns
     fn callable_name(&self, node: &NodeMatcher<CallableRef>) -> Option<NodeMatcher<String>>;
+
+    /// Returns True if the given callable contains a parse error (according to
+    /// tree-sitter)
+    fn callable_has_parse_error(&self, node: &NodeMatcher<CallableRef>) -> NodeMatcher<bool>;
 }

--- a/src/compile/method_library.rs
+++ b/src/compile/method_library.rs
@@ -86,6 +86,29 @@ fn callable_get_a_parameter<'a>(
     }
 }
 
+/// Returns True if the method contains a parse error
+///
+/// Implements:
+/// - [ref:library:Callable:hasParseError]
+/// - [ref:library:Function:hasParseError]
+/// - [ref:library:Method:hasParseError]
+fn callable_has_parse_error<'a>(
+    ti: Rc<dyn TreeInterface>,
+    base: &'a NodeFilter,
+    operands: &'a Vec<Expr<Typed>>,
+) -> anyhow::Result<NodeFilter> {
+    assert!(operands.is_empty());
+    match base {
+        NodeFilter::CallableComputation(callable_matcher) => {
+            let error_matcher = ti.callable_has_parse_error(callable_matcher);
+            Ok(NodeFilter::Predicate(error_matcher))
+        },
+        _ => {
+            panic!("Implementation error: only callables should be possible here");
+        }
+    }
+}
+
 /// Match a string against a regular expression
 ///
 /// Implements:
@@ -260,6 +283,8 @@ fn validate_library(impls: &HashMap<(Type, String), Handler>) {
 ///
 /// The keys of the map are the base type and the method name being looked
 /// up. The value in the map is the handler for that method in the planner.
+///
+/// [tag:method_impls_map]
 static METHOD_IMPLS: Lazy<HashMap<(Type, String), Handler>> = Lazy::new(|| {
     let mut impls = HashMap::new();
 
@@ -287,6 +312,19 @@ static METHOD_IMPLS: Lazy<HashMap<(Type, String), Handler>> = Lazy::new(|| {
     impls.insert(
         (Type::Callable, "getAParameter".into()),
         Handler(Arc::new(callable_get_a_parameter)),
+    );
+
+    impls.insert(
+        (Type::Method, "hasParseError".into()),
+        Handler(Arc::new(callable_has_parse_error)),
+    );
+    impls.insert(
+        (Type::Function, "hasParseError".into()),
+        Handler(Arc::new(callable_has_parse_error)),
+    );
+    impls.insert(
+        (Type::Callable, "hasParseError".into()),
+        Handler(Arc::new(callable_has_parse_error)),
     );
 
     impls.insert(

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -15,6 +15,10 @@ pub enum SourceError {
     ParseError(PathBuf),
 }
 
+/// The languages supported by ql-grep; these are used for run-time selection of
+/// language-specific adapters in the query engine.
+///
+/// [tag:language_enum_definition]
 #[derive(Debug, Copy, Clone)]
 pub enum Language {
     CPP,

--- a/tests/codebases/feature/has-parse-error/ParseError.java
+++ b/tests/codebases/feature/has-parse-error/ParseError.java
@@ -1,0 +1,5 @@
+class ParseError {
+    public static void target() {
+        \
+    }
+}

--- a/tests/codebases/feature/has-parse-error/parse_error.c
+++ b/tests/codebases/feature/has-parse-error/parse_error.c
@@ -1,0 +1,9 @@
+void target() {
+  int x = 1;
+  ,
+}
+
+int ok_func() {
+  int x = 11;
+  return 5 + x;
+}

--- a/tests/integration/4-has-parse-errors.toml
+++ b/tests/integration/4-has-parse-errors.toml
@@ -1,0 +1,11 @@
+# Find all callables that have a parse error (across multiple languages)
+#
+# Make sure there is a source file for each language with at least one parse error
+
+query = """
+from Callable c
+where c.hasParseError()
+select c
+"""
+codebase = "feature/has-parse-error"
+num_matches = 2

--- a/tests/integration/5-has-parse-error-method-only.toml
+++ b/tests/integration/5-has-parse-error-method-only.toml
@@ -1,0 +1,12 @@
+# Find all methods that have a parse error (across multiple languages)
+#
+# Note that this does not match the C example because C does not have methods
+# (neither does C++, according to the tree-sitter grammar)
+
+query = """
+from Method m
+where m.hasParseError()
+select m
+"""
+codebase = "feature/has-parse-error"
+num_matches = 1


### PR DESCRIPTION
This method returns True if a callable has a parse error (according to tree-sitter).  It is implemented for C/C++/Java.

This commit also includes more documentation on development, including the steps for a few common tasks.