### PR TITLE
"Improve" parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -247,6 +247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +393,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +496,7 @@ dependencies = [
  "knuffel",
  "lazy_static",
  "miette",
+ "num_cpus",
  "once_cell",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ignore = "^0.4"
 knuffel = "^2"
 lazy_static = "^1.4"
 miette = { version = "^4.3", features=["fancy"] }
+num_cpus = "^1"
 once_cell = "^1.16"
 regex = "^1"
 tracing = "^0.1"

--- a/src/bin/qg/cli.rs
+++ b/src/bin/qg/cli.rs
@@ -17,4 +17,6 @@ pub struct Cli {
     pub print_library: bool,
     #[arg(long, help = "A file to write log events to (instead of stderr)")]
     pub log_file: Option<PathBuf>,
+    #[arg(long, help = "The number of threads to use (default: all)")]
+    pub num_threads: Option<usize>,
 }

--- a/src/bin/qg/main.rs
+++ b/src/bin/qg/main.rs
@@ -218,7 +218,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     WalkBuilder::new(root_dir)
-        .threads(8)
+        .threads(args.num_threads.unwrap_or(num_cpus::get()))
         .build_parallel()
         .run(|| {
             let q = &typed_select;


### PR DESCRIPTION
Before, `ql-grep` was hard-coded to use 8 threads to search in parallel.  Now there is a command line option to control the number of threads to use, with the default being all threads supported by the CPU.

This is very greedy and unkind to everything else on the system, but is very fast.  The heuristic could change in the future.