### PR TITLE
Implement the `Callable.getType` method

### DIFF
--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -19,7 +19,8 @@ type "Function" {
     method "getParameter" type="Parameter" status="Unimplemented" {
         parameter "index" type="int"
     }
-    method "getType" type="Type" status="Unimplemented" tag="[tag:library:function:getType]"
+    method "getType" type="Type" tag="[tag:library:Function:getType]" \
+        docstring=r"Get the return type of the method"
     method "getName" type="string" tag="[tag:library:Function:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
@@ -35,7 +36,8 @@ type "Method" {
     method "getParameter" type="Parameter" status="Unimplemented" {
         parameter "index" type="int"
     }
-    method "getType" type="Type" status="Unimplemented"
+    method "getType" type="Type" tag="[tag:library:Method:getType]" \
+        docstring=r"Get the return type of the method"
     method "getName" type="string" tag="[tag:library:Method:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
@@ -51,7 +53,8 @@ type "Callable" {
     method "getParameter" type="Parameter" status="Unimplemented" {
         parameter "index" type="int"
     }
-    method "getType" type="Type" status="Unimplemented"
+    method "getType" type="Type" tag="[tag:library:Callable:getType]" \
+        docstring=r"Get the return type of the callable"
     method "getName" type="string" tag="[tag:library:Callable:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"

--- a/src/compile/interface.rs
+++ b/src/compile/interface.rs
@@ -194,4 +194,7 @@ pub trait TreeInterface {
     /// Returns True if the given callable contains a parse error (according to
     /// tree-sitter)
     fn callable_has_parse_error(&self, node: &NodeMatcher<CallableRef>) -> NodeMatcher<bool>;
+
+    /// Returns the return type of the callable
+    fn callable_return_type(&self, node: &NodeMatcher<CallableRef>) -> Option<NodeMatcher<LanguageType>>;
 }

--- a/tests/codebases/feature/0008-return-type-access/Test.java
+++ b/tests/codebases/feature/0008-return-type-access/Test.java
@@ -1,0 +1,9 @@
+class Test {
+    void m1() {
+
+    }
+
+    int m2() {
+        return 0;
+    }
+}

--- a/tests/codebases/feature/0008-return-type-access/test.c
+++ b/tests/codebases/feature/0008-return-type-access/test.c
@@ -1,0 +1,11 @@
+void f1() {
+
+}
+
+double f2() {
+  return 0;
+}
+
+int f3(int x) {
+  return x;
+}

--- a/tests/integration/0008-return-type-access.toml
+++ b/tests/integration/0008-return-type-access.toml
@@ -1,0 +1,9 @@
+# Check that getting the return type of a callable works
+
+query = """
+from Callable c
+where c.getType().getName() = "int"
+select c
+"""
+codebase = "feature/0008-return-type-access"
+num_matches = 2


### PR DESCRIPTION
It is also supported for `Function` and `Method`.  Note that while it is implemented for C++, the type parsing for C++ is currently slightly broken w.r.t. declarators and modifiers.