### PR TITLE
Add support for queries that can refer to imports/includes

### DIFF
--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -11,6 +11,20 @@
 //   - boolean
 //   - string
 
+type "File" {
+    contains "Function"
+    contains "Method"
+    contains "Callable"
+    contains "Import"
+    method "getAnImport" type="Relational<Import>" tag="[tag:library:File:getAnImport]" requires="Imports" \
+        docstring=r"Get an import or include directive in this `File`"
+}
+
+type "Import" {
+    method "getName" type="string" tag="[tag:library:Import:getName]" \
+        docstring=r"Get the name of the imported entity; this is a filename for an import or a (possibly qualified) module name"
+}
+
 type "Function" {
     contains "Parameter"
     contains "Call"
@@ -20,12 +34,14 @@ type "Function" {
         parameter "index" type="int"
     }
     method "getType" type="Type" tag="[tag:library:Function:getType]" \
-        docstring=r"Get the return type of the method"
+        docstring=r"Get the return type of the `Function`"
     method "getName" type="string" tag="[tag:library:Function:getName]"
     method "getACall" type="Relational<Call>" status="Unimplemented" \
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Function:hasParseError]" \
         docstring=r"Returns True if the function contains a parse error"
+    method "getFile" type="File" tag="[tag:library:Function:getFile]" \
+        docstring=r"Returns the `File` containing this `Function`"
 }
 
 type "Method" {
@@ -43,6 +59,8 @@ type "Method" {
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Method:hasParseError]" \
         docstring=r"Returns True if the method contains a parse error"
+    method "getFile" type="File" tag="[tag:library:Method:getFile]" \
+        docstring=r"Returns the `File` containing this `Method`"
 }
 
 type "Callable" {
@@ -60,6 +78,8 @@ type "Callable" {
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Callable:hasParseError]" \
         docstring=r"Returns True if the callable contains a parse error"
+    method "getFile" type="File" tag="[tag:library:Callable:getFile]" \
+        docstring=r"Returns the `File` containing this `Callable`"
 }
 
 // Parameters are *formal* parameters of function definitions/declarations

--- a/src/bin/qg/main.rs
+++ b/src/bin/qg/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::FmtSubscriber;
 
 use ql_grep::{
     compile_query, evaluate_plan, make_tree_interface, parse_query, plan_query, typecheck_query, QueryPlan, QueryResult, Select,
-    SourceFile, Syntax, TreeInterface, Typed, LIBRARY_DATA,
+    SourceFile, Syntax, TreeInterface, TypedQuery, LIBRARY_DATA,
 };
 
 mod cli;
@@ -171,12 +171,12 @@ fn initialize_logging(log_file_path: &Option<PathBuf>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn print_query_ir(query: &Select<Syntax>, typed_query: &Select<Typed>, query_plan: &QueryPlan) {
+fn print_query_ir(query: &Select<Syntax>, typed_query: &TypedQuery, query_plan: &QueryPlan) {
     println!("# Parsed Query");
     println!("{}", query.to_pretty(100));
 
     println!("\n# Typechecked Query");
-    println!("{}", typed_query.to_pretty(100));
+    println!("{}", typed_query.query.to_pretty(100));
 
     println!("\n# Query Plan");
     println!("{}", query_plan.to_pretty(100));
@@ -201,11 +201,11 @@ fn main() -> anyhow::Result<()> {
     let root_dir = args.root.unwrap_or(cwd);
 
     let query = make_query(&args.query_string, &args.query_path)?;
-    let typed_select = typecheck_query(&query)?;
-    let query_plan = plan_query(&typed_select)?;
+    let typed_query = typecheck_query(&query)?;
+    let query_plan = plan_query(&typed_query)?;
 
     if args.print_query_ir {
-        print_query_ir(&query, &typed_select, &query_plan);
+        print_query_ir(&query, &typed_query, &query_plan);
         std::process::exit(0);
     }
 

--- a/src/compile/backend.rs
+++ b/src/compile/backend.rs
@@ -1,2 +1,19 @@
 pub mod cpp;
 pub mod java;
+
+use std::rc::Rc;
+
+use crate::compile::interface::TreeInterface;
+use crate::source_file::Language;
+
+/// Examine the given source file and determine which tree-sitter adapter to use
+/// while processing it.
+///
+/// [tag:tree_sitter_interface_dispatcher]
+pub fn make_tree_interface(lang: Language) -> Rc<dyn TreeInterface> {
+    match lang {
+        Language::Cpp => Rc::new(cpp::CPPTreeInterface::new()) as Rc<dyn TreeInterface>,
+        Language::Java => Rc::new(java::JavaTreeInterface::new()) as Rc<dyn TreeInterface>,
+        Language::Python => unimplemented!(),
+    }
+}

--- a/src/compile/interface.rs
+++ b/src/compile/interface.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use tree_sitter::Node;
 
-use crate::preprocess::FileImportIndex;
+use crate::preprocess::{FileImportIndex, Import};
 use crate::query::val_type::Type;
 
 pub struct TopLevelMatcher {
@@ -130,6 +130,12 @@ impl<'a> EvaluationContext<'a> {
     pub fn flush_bindings(&mut self) {
         self.callables.clear();
         self.parameters.clear();
+    }
+
+    pub fn imports(&self) -> &[Import] {
+        let idx = self.file_imports.as_ref()
+            .unwrap_or_else(|| panic!("The query plan required a computed FileImportIndex, but it was not available"));
+        idx.imports()
     }
 }
 

--- a/src/compile/lift.rs
+++ b/src/compile/lift.rs
@@ -144,6 +144,22 @@ where
                 }
             }
         }
+        NodeFilter::ImportListComputation(import_list_matcher) => {
+            match result_type.base_if_relational() {
+                Type::PrimString => {
+                    let matcher = transform_body(
+                        import_list_matcher,
+                        NodeFilter::ImportComputation,
+                        as_string,
+                        xfrm,
+                    );
+                    Some(NodeFilter::StringListComputation(matcher))
+                }
+                _ => {
+                    panic!("Unsupported conversion from `Import` to `{result_type}`");
+                }
+            }
+        }
         _ => None,
     }
 }

--- a/src/compile/node_filter.rs
+++ b/src/compile/node_filter.rs
@@ -1,4 +1,5 @@
 use crate::compile::interface::{CallableRef, FormalArgument, LanguageType, NodeMatcher};
+use crate::preprocess::Import;
 use crate::query::ir::CachedRegex;
 
 pub enum NodeFilter {
@@ -13,6 +14,13 @@ pub enum NodeFilter {
     CallableComputation(NodeMatcher<CallableRef>),
     ArgumentComputation(NodeMatcher<FormalArgument>),
     ArgumentListComputation(NodeMatcher<Vec<FormalArgument>>),
+    ImportComputation(NodeMatcher<Import>),
+    ImportListComputation(NodeMatcher<Vec<Import>>),
+    /// Currently it is not possible to reference other files during evaluation
+    /// (and it is unlikely that it ever will be possible), so no real
+    /// information is required during evaluation (the File reference is in the
+    /// evaluation context)
+    FileComputation,
 }
 
 impl NodeFilter {
@@ -29,7 +37,10 @@ impl NodeFilter {
             NodeFilter::RegexComputation(_) => "Regex".into(),
             NodeFilter::CallableComputation(_) => "Callable".into(),
             NodeFilter::ArgumentComputation(_) => "Parameter".into(),
-            NodeFilter::ArgumentListComputation(_) => "[Parameter".into(),
+            NodeFilter::ArgumentListComputation(_) => "[Parameter]".into(),
+            NodeFilter::ImportComputation(_) => "Import".into(),
+            NodeFilter::ImportListComputation(_) => "[Import]".into(),
+            NodeFilter::FileComputation => "File".into(),
         }
     }
 }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -76,6 +76,15 @@ fn evaluate_filter<'a, 'b: 'a>(
         NodeFilter::TypeListComputation(_c) => {
             panic!("Not evaluating type lists");
         }
+        NodeFilter::ImportComputation(_c) => {
+            panic!("Not evaluating top-level import computations");
+        }
+        NodeFilter::ImportListComputation(_c) => {
+            panic!("Not evaluating top-level import lists");
+        }
+        NodeFilter::FileComputation => {
+            panic!("Not evaluating file computations");
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,13 @@ mod compile;
 mod evaluate;
 mod library;
 mod plan;
+mod preprocess;
 mod query;
 mod source_file;
 
+pub use crate::compile::backend::make_tree_interface;
 pub use crate::compile::compile_query;
+pub use crate::compile::interface::TreeInterface;
 pub use crate::evaluate::{evaluate_plan, QueryResult};
 pub use crate::library::LIBRARY_DATA;
 pub use crate::plan::{plan_query, QueryPlan};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,5 @@ pub use crate::library::LIBRARY_DATA;
 pub use crate::plan::{plan_query, QueryPlan};
 pub use crate::query::ir::{Select, Syntax, Typed};
 pub use crate::query::parse_query;
-pub use crate::query::typecheck::typecheck_query;
+pub use crate::query::typecheck::{TypedQuery, typecheck_query};
 pub use crate::source_file::SourceFile;

--- a/src/library.rs
+++ b/src/library.rs
@@ -11,6 +11,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 use crate::query::val_type;
+use crate::preprocess::FilePreprocessingPass;
 
 pub const LIBRARY_DATA: &str = include_str!("../doc/library.kdl");
 
@@ -64,6 +65,8 @@ pub struct Method {
     pub parameters: Vec<Parameter>,
     #[knuffel(property, str)]
     pub tag: Option<String>,
+    #[knuffel(property, str)]
+    pub requires: Option<FilePreprocessingPass>,
 }
 
 /// This type is factored out so that we can use the `str` knuffel parser; it

--- a/src/library.rs
+++ b/src/library.rs
@@ -99,6 +99,8 @@ fn drop_aggregate_types(ty: val_type::Type) -> val_type::Type {
         val_type::Type::Regex => ty,
         val_type::Type::Expr => ty,
         val_type::Type::Call => ty,
+        val_type::Type::Import => ty,
+        val_type::Type::File => ty,
         val_type::Type::Parameter => ty,
         val_type::Type::PrimString => ty,
         val_type::Type::PrimInteger => ty,

--- a/src/library/index.rs
+++ b/src/library/index.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
 use crate::library;
+use crate::preprocess::FilePreprocessingPass;
 use crate::query::val_type::Type;
 
 pub struct MethodSignature(
@@ -10,6 +11,7 @@ pub struct MethodSignature(
     pub Vec<Type>,
     pub Type,
     pub Option<library::Status>,
+    pub Option<FilePreprocessingPass>,
 );
 pub struct TypeIndex {
     pub method_index: HashMap<String, MethodSignature>,
@@ -27,6 +29,7 @@ fn build_method_signature(method: &library::Method) -> MethodSignature {
         param_types,
         method.type_.clone(),
         method.status,
+        method.requires,
     )
 }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -9,6 +9,7 @@ use pretty::RcDoc;
 use std::collections::HashSet;
 
 use crate::library::index::library_index;
+use crate::preprocess::FilePreprocessingPass;
 use crate::query::ir::{AsExpr, EqualityOp, Expr, Expr_, Select, Typed, VarDecl};
 use crate::query::val_type::Type;
 
@@ -26,6 +27,7 @@ pub struct QueryPlan {
     pub where_formula: Expr<Typed>,
     pub var_decls: Vec<VarDecl>,
     pub root_var: VarDecl,
+    pub file_preprocessing: HashSet<FilePreprocessingPass>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -268,6 +270,7 @@ pub fn plan_query(query: &Select<Typed>) -> anyhow::Result<QueryPlan> {
         where_formula: rewritten_expr,
         var_decls: query.var_decls.clone(),
         root_var: outermost_var,
+        file_preprocessing: HashSet::new(),
     };
 
     Ok(qp)

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,0 +1,43 @@
+/// File-level preprocessing passes required for evaluation
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum FilePreprocessingPass {
+    /// Preprocess the file and collect all of the imports and includes
+    Imports,
+}
+
+/// The concrete types of imports supported
+///
+/// No language supports all of these, but having this top-level type simplifies
+/// things substantially over having language-specific imports.  This could
+/// change in the future if we want additional precision in our representation.
+#[derive(Debug)]
+pub enum Import {
+    /// A C/C++ include using angle brackets to reference a system-level include
+    /// file on the search path
+    IncludeSystem(String),
+    /// A C/C++ include using double quotes to include a local file
+    IncludeLocal(String),
+    /// An unqualified import (at least for Java). Note that this is currently
+    /// used for all imports; Java imports could be broken down into more types
+    Import(String),
+}
+
+/// An index of all of the imports in a single file.
+///
+/// This is a simple wrapper right now, but is abstract to make it easier to
+/// refactor later.
+pub struct FileImportIndex {
+    imports: Vec<Import>,
+}
+
+impl FileImportIndex {
+    pub fn new() -> Self {
+        FileImportIndex {
+            imports: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, i: Import) {
+        self.imports.push(i);
+    }
+}

--- a/src/query/val_type.rs
+++ b/src/query/val_type.rs
@@ -17,10 +17,12 @@ where
         string("boolean").map(|_| Type::PrimBoolean),
         string("string").map(|_| Type::PrimString),
         string("Expr").map(|_| Type::Expr),
-        string("Function").map(|_| Type::Function),
         string("Method").map(|_| Type::Method),
         string("Parameter").map(|_| Type::Parameter),
         string("Type").map(|_| Type::Type),
+        string("Import").map(|_| Type::Import),
+        attempt(string("Function").map(|_| Type::Function)),
+        attempt(string("File").map(|_| Type::File)),
         attempt(string("Class").map(|_| Type::Class)),
         attempt(string("Callable").map(|_| Type::Callable)),
         attempt(string("Call").map(|_| Type::Call)),
@@ -83,6 +85,8 @@ pub enum Type {
     Call,
     Expr,
     Field,
+    Import,
+    File,
     /// Values that appear in a relational context (and might be evaluated as a list or as a logic expression)
     Relational(Box<Type>),
     /// A list of values
@@ -120,6 +124,8 @@ impl fmt::Display for Type {
             Type::Class => write!(f, "Class"),
             Type::Call => write!(f, "Call"),
             Type::Expr => write!(f, "Expr"),
+            Type::Import => write!(f, "Import"),
+            Type::File => write!(f, "File"),
             Type::Regex => write!(f, "Regex"),
             Type::List(ty) => {
                 write!(f, "List<")?;
@@ -148,6 +154,8 @@ impl Type {
             Type::Regex => false,
             Type::Call => false,
             Type::Expr => false,
+            Type::File => false,
+            Type::Import => false,
             Type::PrimString => false,
             Type::PrimInteger => false,
             Type::PrimBoolean => false,
@@ -176,6 +184,8 @@ impl Type {
             | Type::Parameter
             | Type::Call
             | Type::Expr
+            | Type::Import
+            | Type::File
             | Type::Field => self.clone(),
         }
     }

--- a/tests/codebases/feature/0009-test-c-include/a-match.c
+++ b/tests/codebases/feature/0009-test-c-include/a-match.c
@@ -1,0 +1,5 @@
+#include <setjmp.h>
+
+void g() {
+
+}

--- a/tests/codebases/feature/0009-test-c-include/no-match.c
+++ b/tests/codebases/feature/0009-test-c-include/no-match.c
@@ -1,0 +1,4 @@
+// This function doesn't match because we don't include setjmp.h
+void f() {
+
+}

--- a/tests/codebases/feature/0010-test-java-import/NoMatch.java
+++ b/tests/codebases/feature/0010-test-java-import/NoMatch.java
@@ -1,0 +1,5 @@
+class NoMatch {
+    public void f() {
+
+    }
+}

--- a/tests/codebases/feature/0010-test-java-import/TwoMatchingMethods.java
+++ b/tests/codebases/feature/0010-test-java-import/TwoMatchingMethods.java
@@ -1,0 +1,11 @@
+import java.util.Map;
+
+class TwoMatchingMethods {
+    public void f() {
+
+    }
+
+    public void m() {
+
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,8 +8,8 @@ use test_generator::test_resources;
 use toml::de;
 
 use ql_grep::{
-    compile_query, evaluate_plan, make_tree_interface, parse_query, plan_query, typecheck_query, QueryResult, Select,
-    SourceFile, Typed,
+    compile_query, evaluate_plan, make_tree_interface, parse_query, plan_query, typecheck_query, QueryResult,
+    SourceFile, TypedQuery,
 };
 
 /// A single test case to run ql-grep over, with expected results
@@ -42,7 +42,7 @@ impl Statistics {
 }
 
 fn visit_file(
-    query: &Select<Typed>,
+    query: &TypedQuery,
     send: Sender<QueryResults>,
     ent: Result<DirEntry, ignore::Error>,
 ) -> WalkState {

--- a/tests/integration/0009-test-c-include.toml
+++ b/tests/integration/0009-test-c-include.toml
@@ -1,0 +1,9 @@
+# Test that queries against indexed file-level includes work for C
+
+query = """
+from Function f
+where f.getFile().getAnImport().getName() = "setjmp.h"
+select f
+"""
+codebase = "feature/0009-test-c-include"
+num_matches = 1

--- a/tests/integration/0010-test-java-import.toml
+++ b/tests/integration/0010-test-java-import.toml
@@ -1,0 +1,10 @@
+# Test that queries against indexed file-level imports work for Java
+
+query = """
+from Method m
+where m.getFile().getAnImport().getName() = "java.util.Map"
+select m
+"""
+
+codebase = "feature/0010-test-java-import"
+num_matches = 2


### PR DESCRIPTION
There are three primary new methods:

- `Callable.getFile`
- `File.getAnImport`
- `Import.getName`

Together, these enable the user to query the list of imports (or includes) in
the file and use them in predicates.  This required new infrastructure to
compute file-level indexes (of imports/includes) before evaluating queries.  The
new indexing pass is driven by tags in the library that indicate which
preprocessing pass each method that requires one depends on.  The system will
automatically run and make the pass available if (and only if) it is required to
evaluate the query.