### PR TITLE
Add new predicates for querying the call sites in functions/methods/callables

### DIFF
--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -36,7 +36,7 @@ type "Function" {
     method "getType" type="Type" tag="[tag:library:Function:getType]" \
         docstring=r"Get the return type of the `Function`"
     method "getName" type="string" tag="[tag:library:Function:getName]"
-    method "getACall" type="Relational<Call>" status="Unimplemented" \
+    method "getACall" type="Relational<Call>"  tag="[tag:library:Function:getACall]" \
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Function:hasParseError]" \
         docstring=r"Returns True if the function contains a parse error"
@@ -55,7 +55,7 @@ type "Method" {
     method "getType" type="Type" tag="[tag:library:Method:getType]" \
         docstring=r"Get the return type of the method"
     method "getName" type="string" tag="[tag:library:Method:getName]"
-    method "getACall" type="Relational<Call>" status="Unimplemented" \
+    method "getACall" type="Relational<Call>"  tag="[tag:library:Method:getACall]" \
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Method:hasParseError]" \
         docstring=r"Returns True if the method contains a parse error"
@@ -74,7 +74,7 @@ type "Callable" {
     method "getType" type="Type" tag="[tag:library:Callable:getType]" \
         docstring=r"Get the return type of the callable"
     method "getName" type="string" tag="[tag:library:Callable:getName]"
-    method "getACall" type="Relational<Call>" status="Unimplemented" \
+    method "getACall" type="Relational<Call>" tag="[tag:library:Callable:getACall]" \
         docstring=r"Return a call expression in the body of this object"
     method "hasParseError" type="boolean" tag="[tag:library:Callable:hasParseError]" \
         docstring=r"Returns True if the callable contains a parse error"
@@ -97,7 +97,7 @@ type "Call" {
         parameter "index" type="int"
     }
     method "getAnArgument" type="Expr" status="Unimplemented"
-    method "getTarget" type="string" status="Unimplemented" \
+    method "getTarget" type="string" tag="[tag:library:Call:getTarget]" \
         docstring=r"Return the target of the call; this is a string because there is not necessarily a structured declaration available"
 }
 

--- a/src/compile/backend/cpp.rs
+++ b/src/compile/backend/cpp.rs
@@ -174,6 +174,62 @@ impl TreeInterface for CPPTreeInterface {
             }),
         }
     }
+
+    fn callable_call_sites(&self, node: &NodeMatcher<CallableRef>) -> NodeListMatcher<Callsite> {
+        let get_callable_ref = Rc::clone(&node.extract);
+        NodeListMatcher {
+            extract: Rc::new(move |ctx, source| {
+                let callable_ref = get_callable_ref(ctx, source);
+                let callable_node = ctx.lookup_callable(&callable_ref.value);
+                let mut cur = tree_sitter::QueryCursor::new();
+                let ql_query = "(call_expression function: (_) @func arguments: (argument_list) @args)";
+                let query = tree_sitter::Query::new(callable_node.language(), ql_query)
+                    .unwrap_or_else(|e| panic!("Error while querying for call sites {e:?}"));
+                let query_matches = cur.matches(&query, *callable_node, source);
+
+                let mut callsites = Vec::new();
+                for query_match in query_matches {
+                    // There are two captures for each query: the function name and the argument list
+                    //
+                    // For now, we just turn the function name into a String; in the future it would be nice to provide
+                    // more detail in the name parsing, but it is hard to do reliably because a bare function pointer can
+                    // look identical to a normal function call.
+                    let call_name_node = query_match.captures[0].node;
+                    let arglist_node = query_match.captures[1].node;
+
+                    let (callsite, expr_bindings) = callable_call_sites_from_nodes(source, &call_name_node, &arglist_node);
+
+                    ctx.add_expression_bindings(expr_bindings);
+
+                    let ranges = vec![call_name_node.range(), arglist_node.range()];
+                    let res = WithRanges::new(callsite, vec![ranges]);
+                    callsites.push(res);
+                }
+
+                callsites
+            }),
+        }
+    }
+}
+
+fn callable_call_sites_from_nodes<'a>(
+    source: &[u8],
+    call_name_node: &Node<'a>,
+    arglist_node: &Node<'a>,
+) -> (Callsite, Vec<(ExprRef, Node<'a>)>) {
+    let name = call_name_node.utf8_text(source).unwrap().into();
+    let mut args = Vec::new();
+    let mut arg_refs = Vec::new();
+
+    let mut cur = arglist_node.walk();
+    for arg_node in arglist_node.named_children(&mut cur) {
+        let expr_ref = ExprRef::new(arg_node.id());
+        arg_refs.push(expr_ref);
+        args.push((expr_ref, arg_node));
+    }
+
+    let callsite = Callsite::new(name, arg_refs);
+    (callsite, args)
 }
 
 fn callable_name_node_to_string(n: &Node, src: &[u8]) -> String {

--- a/src/compile/node_filter.rs
+++ b/src/compile/node_filter.rs
@@ -1,5 +1,5 @@
 use crate::compile::interface::{
-    CallableRef, FormalArgument, LanguageType, NodeListMatcher, NodeMatcher,
+    CallableRef, Callsite, FormalArgument, LanguageType, NodeListMatcher, NodeMatcher,
 };
 use crate::preprocess::Import;
 use crate::query::ir::CachedRegex;
@@ -14,6 +14,8 @@ pub enum NodeFilter {
     StringListComputation(NodeListMatcher<String>),
     RegexComputation(NodeMatcher<CachedRegex>),
     CallableComputation(NodeMatcher<CallableRef>),
+    CallsiteComputation(NodeMatcher<Callsite>),
+    CallsiteListComputation(NodeListMatcher<Callsite>),
     ArgumentComputation(NodeMatcher<FormalArgument>),
     ArgumentListComputation(NodeListMatcher<FormalArgument>),
     ImportComputation(NodeMatcher<Import>),
@@ -38,6 +40,8 @@ impl NodeFilter {
             NodeFilter::StringListComputation(_) => "[string]".into(),
             NodeFilter::RegexComputation(_) => "Regex".into(),
             NodeFilter::CallableComputation(_) => "Callable".into(),
+            NodeFilter::CallsiteComputation(_) => "Callsite".into(),
+            NodeFilter::CallsiteListComputation(_) => "[Callsite]".into(),
             NodeFilter::ArgumentComputation(_) => "Parameter".into(),
             NodeFilter::ArgumentListComputation(_) => "[Parameter]".into(),
             NodeFilter::ImportComputation(_) => "Import".into(),

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -94,6 +94,12 @@ fn evaluate_filter<'a, 'b: 'a>(
         NodeFilter::FileComputation => {
             panic!("Not evaluating file computations");
         }
+        NodeFilter::CallsiteComputation(_c) => {
+            panic!("Not evaluating callsite computations");
+        }
+        NodeFilter::CallsiteListComputation(_c) => {
+            panic!("Not evaluating callsite list computations");
+        }
     }
 }
 

--- a/tests/codebases/feature/0011-c-callsite-target-name/test.c
+++ b/tests/codebases/feature/0011-c-callsite-target-name/test.c
@@ -1,0 +1,13 @@
+void func1() {
+  pre_call();
+  printf("foo: %s\n", global_string);
+  post_call(itoa(""));
+}
+
+void func2() {
+  func1();
+}
+
+void func3() {
+  strlen();
+}

--- a/tests/codebases/feature/0012-java-callsite-target-name/Test.java
+++ b/tests/codebases/feature/0012-java-callsite-target-name/Test.java
@@ -1,0 +1,13 @@
+class Test {
+    private void method1() {
+        log.info("method1");
+    }
+
+    public int method2(int i) {
+        return i + foo();
+    }
+
+    public Editor method(Context c0) {
+        return c0.getBean("Editor");
+    }
+}

--- a/tests/integration/0011-c-callsite-target-name.toml
+++ b/tests/integration/0011-c-callsite-target-name.toml
@@ -1,0 +1,10 @@
+# Test that queries against call site names work in C
+
+query = """
+from Function f, Call c
+where c = f.getACall() and c.getTarget() = "printf"
+select f
+"""
+
+codebase = "feature/0011-c-callsite-target-name"
+num_matches = 1

--- a/tests/integration/0012-java-callsite-target-name.toml
+++ b/tests/integration/0012-java-callsite-target-name.toml
@@ -1,0 +1,11 @@
+# Test that queries against call site names work in Java
+
+query = """
+from Method m, Call c
+where c = m.getACall() and c.getTarget() = "getBean"
+select m
+"""
+
+codebase = "feature/0012-java-callsite-target-name"
+num_matches = 1
+


### PR DESCRIPTION
The new predicate is `getACall`, which returns a relation containing all call sites in the associated function/method/callable. That is complemented with a new type, `Call`, which has a new method `getTarget`.  For now, the target is just a string that can be matched against.  See the test cases for example queries.