### PR TITLE
Enable evaluation functions to fail gracefully

### DIFF
--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -93,7 +93,7 @@ type "Parameter" {
 
 type "Call" {
     contains "Expr"
-    method "getArgument" type="Expr" status="Unimplemented" {
+    method "getArgument" type="Expr" tag="[tag:library:Call:getArgument]" {
         parameter "index" type="int"
     }
     method "getAnArgument" type="Expr" status="Unimplemented"

--- a/doc/library.kdl
+++ b/doc/library.kdl
@@ -104,6 +104,8 @@ type "Call" {
 type "Expr" {
     method "isCompileTimeConstant" type="boolean" status="Unimplemented" \
         docstring=r"Returns `true` if the expression is a literal at compile time"
+    method "isStringLiteral" type="boolean" tag="[tag:library:Expr:isStringLiteral]" \
+        docstring=r"Returns `true` if the expression is a string literal"
 }
 
 type "Type" {

--- a/src/compile/backend/cpp.rs
+++ b/src/compile/backend/cpp.rs
@@ -215,6 +215,10 @@ impl TreeInterface for CPPTreeInterface {
             }),
         }
     }
+
+    fn expr_is_string_literal(&self, node: &Node) -> bool {
+        node.kind() == "string_literal"
+    }
 }
 
 fn callable_call_sites_from_nodes<'a>(

--- a/src/compile/backend/java.rs
+++ b/src/compile/backend/java.rs
@@ -185,6 +185,10 @@ impl TreeInterface for JavaTreeInterface {
             }),
         }
     }
+
+    fn expr_is_string_literal(&self, node: &Node) -> bool {
+        node.kind() == "string_literal"
+    }
 }
 
 fn callable_call_sites_from_nodes<'a>(

--- a/src/compile/interface.rs
+++ b/src/compile/interface.rs
@@ -198,10 +198,13 @@ impl<'a> Default for EvaluationContext<'a> {
 /// For example, a query might select argument nodes and the matcher could
 /// extract a list of argument structures.
 pub struct NodeMatcher<R> {
-    pub extract: Rc<dyn for<'b, 'a> Fn(&'b mut EvaluationContext<'a>, &'a [u8]) -> WithRanges<R>>,
+    pub extract: Rc<dyn for<'b, 'a> Fn(&'b mut EvaluationContext<'a>, &'a [u8]) -> Option<WithRanges<R>>>,
 }
 
 /// A variant of `NodeMatcher` for sequences/relations
+///
+/// Note that, unlike the scalar `NodeMatcher`, this version does not need an
+/// `Option` to indicate failure. It can simply return an empty sequence.
 pub struct NodeListMatcher<R> {
     pub extract:
         Rc<dyn for<'b, 'a> Fn(&'b mut EvaluationContext<'a>, &'a [u8]) -> Vec<WithRanges<R>>>,

--- a/src/compile/interface.rs
+++ b/src/compile/interface.rs
@@ -133,6 +133,10 @@ impl<'a> EvaluationContext<'a> {
         }
     }
 
+    pub fn lookup_expression(&self, expr_id: &ExprRef) -> Node<'a> {
+        *self.expr_nodes.get(expr_id).unwrap()
+    }
+
     pub fn attach_file_import_index(&mut self, file_imports: FileImportIndex) {
         self.file_imports = Some(file_imports);
     }
@@ -307,4 +311,7 @@ pub trait TreeInterface {
 
     /// Return the callsites in the given callable
     fn callable_call_sites(&self, node: &NodeMatcher<CallableRef>) -> NodeListMatcher<Callsite>;
+
+    /// Returns true if the given node is a string literal expression
+    fn expr_is_string_literal(&self, node: &Node) -> bool;
 }

--- a/src/compile/lift.rs
+++ b/src/compile/lift.rs
@@ -61,14 +61,15 @@ where
                 // that the scalar processor (the transformer, above) can
                 // process it unmodified
                 let wrapper_matcher = NodeMatcher {
-                    extract: Rc::new(move |_ctx, _source| arg.clone()),
+                    extract: Rc::new(move |_ctx, _source| Some(arg.clone())),
                 };
 
                 let wrapper_filter = wrap_one(wrapper_matcher);
                 let result_filter = xfrm(Rc::new(wrapper_filter)).unwrap();
                 let comp = extract_one(result_filter);
-                let val = (comp.extract)(ctx, source);
-                res.push(val);
+                (comp.extract)(ctx, source).map(|val| {
+                    res.push(val);
+                });
             }
 
             res

--- a/src/compile/node_filter.rs
+++ b/src/compile/node_filter.rs
@@ -1,5 +1,5 @@
 use crate::compile::interface::{
-    CallableRef, Callsite, FormalArgument, LanguageType, NodeListMatcher, NodeMatcher,
+    CallableRef, Callsite, ExprRef, FormalArgument, LanguageType, NodeListMatcher, NodeMatcher,
 };
 use crate::preprocess::Import;
 use crate::query::ir::CachedRegex;
@@ -20,6 +20,7 @@ pub enum NodeFilter {
     ArgumentListComputation(NodeListMatcher<FormalArgument>),
     ImportComputation(NodeMatcher<Import>),
     ImportListComputation(NodeListMatcher<Import>),
+    ExprComputation(NodeMatcher<ExprRef>),
     /// Currently it is not possible to reference other files during evaluation
     /// (and it is unlikely that it ever will be possible), so no real
     /// information is required during evaluation (the File reference is in the
@@ -46,6 +47,7 @@ impl NodeFilter {
             NodeFilter::ArgumentListComputation(_) => "[Parameter]".into(),
             NodeFilter::ImportComputation(_) => "Import".into(),
             NodeFilter::ImportListComputation(_) => "[Import]".into(),
+            NodeFilter::ExprComputation(_) => "Expr".into(),
             NodeFilter::FileComputation => "File".into(),
         }
     }

--- a/tests/codebases/feature/0013-printf-literal-format/test.c
+++ b/tests/codebases/feature/0013-printf-literal-format/test.c
@@ -1,0 +1,9 @@
+// Match
+void f1(const char* s) {
+  printf("Literal string: %s\n", s);
+}
+
+// No match
+void f2(const char* s1, const char* s2) {
+  printf(s1, s2);
+}

--- a/tests/codebases/feature/0014-fprintf-literal-format/test.c
+++ b/tests/codebases/feature/0014-fprintf-literal-format/test.c
@@ -1,0 +1,9 @@
+// Match
+void f1(const char* s) {
+  fprintf(stderr, "Literal string: %s\n", s);
+}
+
+// No match
+void f2(const char* s1, const char* s2) {
+  fprintf(stderr, s1, s2);
+}

--- a/tests/integration/0013-printf-literal-format.toml
+++ b/tests/integration/0013-printf-literal-format.toml
@@ -1,0 +1,12 @@
+# Test that the callsite and expr queries work by finding printf calls that do not have a literal format string
+#
+# Note the test is actually checking the opposite because we don't have negation yet
+
+query = """
+from Function f, Call c
+where c = f.getACall() and (c.getTarget() = "printf" and c.getArgument(0).isStringLiteral())
+select f
+"""
+
+codebase = "feature/0013-printf-literal-format"
+num_matches = 1

--- a/tests/integration/0014-fprintf-literal-format.toml
+++ b/tests/integration/0014-fprintf-literal-format.toml
@@ -1,0 +1,14 @@
+# Test that the callsite and expr queries work by finding fprintf calls that do not have a literal format string
+#
+# NOTE: the test is actually checking the opposite because we don't have negation yet
+#
+# NOTE: compared to 0013, this test targets fprintf to ensure that non-zero indexes work
+
+query = """
+from Function f, Call c
+where c = f.getACall() and (c.getTarget() = "fprintf" and c.getArgument(1).isStringLiteral())
+select f
+"""
+
+codebase = "feature/0014-fprintf-literal-format"
+num_matches = 1


### PR DESCRIPTION
This enables scalar evaluations to fail, indicating to the evaluator that the branch is not valid.  At the top level, these generally turn into failed matches.  This is important to support CodeQL predicates that can fail (like the argument list indexing predicate included in this patch).