### PR TITLE
Keep the source bytes in the evaluation context

### DIFF
--- a/src/compile/lift.rs
+++ b/src/compile/lift.rs
@@ -53,21 +53,21 @@ where
     let args_extract = Rc::clone(&base_elts.extract);
 
     NodeListMatcher {
-        extract: Rc::new(move |ctx, source| {
+        extract: Rc::new(move |ctx| {
             let mut res = Vec::new();
 
-            for arg in args_extract(ctx, source) {
+            for arg in args_extract(ctx) {
                 // Wrap each element in the carrier type for single elements so
                 // that the scalar processor (the transformer, above) can
                 // process it unmodified
                 let wrapper_matcher = NodeMatcher {
-                    extract: Rc::new(move |_ctx, _source| Some(arg.clone())),
+                    extract: Rc::new(move |_ctx| Some(arg.clone())),
                 };
 
                 let wrapper_filter = wrap_one(wrapper_matcher);
                 let result_filter = xfrm(Rc::new(wrapper_filter)).unwrap();
                 let comp = extract_one(result_filter);
-                (comp.extract)(ctx, source).map(|val| {
+                (comp.extract)(ctx).map(|val| {
                     res.push(val);
                 });
             }

--- a/src/compile/method_library.rs
+++ b/src/compile/method_library.rs
@@ -47,8 +47,8 @@ fn string_regexp_match<'a>(
     };
     let get_string = Rc::clone(&c.extract);
     let comp = NodeMatcher {
-        extract: Rc::new(move |ctx, source| {
-            get_string(ctx, source).map(|matched_string| {
+        extract: Rc::new(move |ctx| {
+            get_string(ctx).map(|matched_string| {
                 WithRanges::new(
                     rx.is_match(matched_string.value.as_ref()),
                     vec![matched_string.ranges],
@@ -73,8 +73,8 @@ fn type_get_name<'a>(
         NodeFilter::TypeComputation(tc) => {
             let get_type = Rc::clone(&tc.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_type(ctx, source).map(|type_result| {
+                extract: Rc::new(move |ctx| {
+                    get_type(ctx).map(|type_result| {
                         WithRanges::new(type_result.value.as_type_string(), vec![type_result.ranges])
                     })
                 }),
@@ -105,7 +105,7 @@ fn file_get_an_import<'a>(
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     let comp = NodeListMatcher {
-        extract: Rc::new(move |ctx, _source| {
+        extract: Rc::new(move |ctx| {
             ctx.imports()
                 .iter()
                 .cloned()
@@ -130,8 +130,8 @@ fn import_get_name<'a>(
         NodeFilter::ImportComputation(c) => {
             let get_import = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_import(ctx, source).map(|import_res| {
+                extract: Rc::new(move |ctx| {
+                    get_import(ctx).map(|import_res| {
                         WithRanges::new(import_res.value.to_string(), vec![import_res.ranges])
                     })
                 }),

--- a/src/compile/method_library/call.rs
+++ b/src/compile/method_library/call.rs
@@ -26,8 +26,8 @@ fn call_get_target(
         NodeFilter::CallsiteComputation(c) => {
             let get_callsite = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_callsite(ctx, source).map(|callsite_res| {
+                extract: Rc::new(move |ctx| {
+                    get_callsite(ctx).map(|callsite_res| {
                         WithRanges::new(callsite_res.value.target_name.clone(), vec![callsite_res.ranges])
                     })
                 }),
@@ -64,8 +64,8 @@ fn call_get_argument(
                 _ => panic!("Invalid argument to Call.getArgument"),
             };
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_callsite(ctx, source).map(|callsite_res| {
+                extract: Rc::new(move |ctx| {
+                    get_callsite(ctx).map(|callsite_res| {
                         let arg_list = callsite_res.value.arguments;
                         if arg_idx < arg_list.len() {
                             Some(WithRanges::value(arg_list[arg_idx]))

--- a/src/compile/method_library/expr.rs
+++ b/src/compile/method_library/expr.rs
@@ -23,8 +23,8 @@ fn expr_is_string_literal(
         NodeFilter::ExprComputation(c) => {
             let get_expr = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_expr(ctx, source).map(|expr_ref| {
+                extract: Rc::new(move |ctx| {
+                    get_expr(ctx).map(|expr_ref| {
                         let expr_node = ctx.lookup_expression(&expr_ref.value);
                         WithRanges::new_single(ti.expr_is_string_literal(&expr_node), expr_node.range())
                     })

--- a/src/compile/method_library/parameter.rs
+++ b/src/compile/method_library/parameter.rs
@@ -24,8 +24,8 @@ fn parameter_get_name<'a>(
         NodeFilter::ArgumentComputation(c) => {
             let get_argument = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_argument(ctx, source).map(|argument_result| {
+                extract: Rc::new(move |ctx| {
+                    get_argument(ctx).map(|argument_result| {
                         WithRanges::new(
                             argument_result
                                 .value
@@ -58,11 +58,11 @@ fn parameter_get_type<'a>(
         NodeFilter::ArgumentComputation(c) => {
             let get_argument = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
+                extract: Rc::new(move |ctx| {
                     // FIXME: Probably want to have a better (i.e., more
                     // structured) representation if the type is missing
                     let default_ty = LanguageType::new("<Any>");
-                    get_argument(ctx, source).map(|argument_result| {
+                    get_argument(ctx).map(|argument_result| {
                         WithRanges::new(
                             argument_result.value.declared_type.unwrap_or(default_ty),
                             vec![argument_result.ranges],
@@ -93,8 +93,8 @@ fn parameter_get_index<'a>(
         NodeFilter::ArgumentComputation(c) => {
             let get_argument = Rc::clone(&c.extract);
             let comp = NodeMatcher {
-                extract: Rc::new(move |ctx, source| {
-                    get_argument(ctx, source).map(|argument_result| {
+                extract: Rc::new(move |ctx| {
+                    get_argument(ctx).map(|argument_result| {
                         WithRanges::new(
                             argument_result.value.index as i32,
                             vec![argument_result.ranges],


### PR DESCRIPTION
This enables removing a parameter from the chains of filter functions, as they all already have access to the context.