### PR TITLE
Compile function arguments in queries

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -571,7 +571,9 @@ fn compile_expr(ti: Rc<dyn TreeInterface>, e: &Expr<Typed>) -> anyhow::Result<No
             match handler {
                 Some(Handler(f)) => {
                     let base_comp = compile_expr(Rc::clone(&ti), base)?;
-                    let ops1 = operands.clone();
+                    let ops1 = operands.iter()
+                        .map(|op| compile_expr(Rc::clone(&ti), op).unwrap())
+                        .collect();
                     f(Rc::clone(&ti), &base_comp, &ops1)
                 }
                 None => {

--- a/src/compile/method_library/callable.rs
+++ b/src/compile/method_library/callable.rs
@@ -6,7 +6,6 @@ use crate::compile::errors::PlanError;
 use crate::compile::interface::TreeInterface;
 use crate::compile::method_library::handler::Handler;
 use crate::compile::NodeFilter;
-use crate::query::ir::*;
 
 /// Get the name of a callable using the language interface
 ///
@@ -17,7 +16,7 @@ use crate::query::ir::*;
 fn callable_get_name<'a>(
     ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     // This is not necessarily an assertion, as this may not be supported for
@@ -44,7 +43,7 @@ fn callable_get_name<'a>(
 fn callable_get_a_parameter<'a>(
     ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {
@@ -69,7 +68,7 @@ fn callable_get_a_parameter<'a>(
 fn callable_has_parse_error<'a>(
     ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {
@@ -92,7 +91,7 @@ fn callable_has_parse_error<'a>(
 fn callable_get_return_type<'a>(
     ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {
@@ -120,7 +119,7 @@ fn callable_get_return_type<'a>(
 fn callable_get_file<'a>(
     _ti: Rc<dyn TreeInterface>,
     _base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     Ok(NodeFilter::FileComputation)
@@ -135,7 +134,7 @@ fn callable_get_file<'a>(
 fn callable_call_sites<'a>(
     ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {

--- a/src/compile/method_library/expr.rs
+++ b/src/compile/method_library/expr.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crate::compile::interface::{NodeMatcher, TreeInterface};
 use crate::compile::method_library::handler::Handler;
 use crate::compile::NodeFilter;
-use crate::query::ir::*;
 use crate::query::val_type::Type;
 use crate::with_ranges::WithRanges;
 
@@ -16,7 +15,7 @@ use crate::with_ranges::WithRanges;
 fn expr_is_string_literal(
     ti: Rc<dyn TreeInterface>,
     base: &NodeFilter,
-    operands: &Vec<Expr<Typed>>,
+    operands: &Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {

--- a/src/compile/method_library/handler.rs
+++ b/src/compile/method_library/handler.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use crate::compile::interface::TreeInterface;
 use crate::compile::NodeFilter;
-use crate::query::ir::*;
 
 /// A handler for method calls (qualified accesses) in the planner
 ///
@@ -11,18 +10,16 @@ use crate::query::ir::*;
 ///
 /// 1. The `TreeInterface` that abstracts the tree-sitter AST query facility
 /// 2. The translated node filter of the receiver object of the method (which may not be needed)
-/// 3. The typed operands of the method call
+/// 3. The operands of the method call
 ///
 /// The callback returns a node filter that is suitable for evaluating the method call
-///
-/// FIXME: The arguments need to be run-time values
 #[derive(Clone)]
 pub struct Handler(
     pub Arc<
         dyn for<'a> Fn(
                 Rc<dyn TreeInterface>,
                 &'a NodeFilter,
-                &'a Vec<Expr<Typed>>,
+                &'a Vec<NodeFilter>,
             ) -> anyhow::Result<NodeFilter>
             + Send
             + Sync,

--- a/src/compile/method_library/parameter.rs
+++ b/src/compile/method_library/parameter.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crate::compile::interface::{LanguageType, NodeMatcher, TreeInterface};
 use crate::compile::method_library::handler::Handler;
 use crate::compile::NodeFilter;
-use crate::query::ir::*;
 use crate::query::val_type::Type;
 use crate::with_ranges::WithRanges;
 
@@ -17,7 +16,7 @@ use crate::with_ranges::WithRanges;
 fn parameter_get_name<'a>(
     _ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {
@@ -51,7 +50,7 @@ fn parameter_get_name<'a>(
 fn parameter_get_type<'a>(
     _ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {
@@ -86,7 +85,7 @@ fn parameter_get_type<'a>(
 fn parameter_get_index<'a>(
     _ti: Rc<dyn TreeInterface>,
     base: &'a NodeFilter,
-    operands: &'a Vec<Expr<Typed>>,
+    operands: &'a Vec<NodeFilter>,
 ) -> anyhow::Result<NodeFilter> {
     assert!(operands.is_empty());
     match base {


### PR DESCRIPTION
Before, these were left as uninterpreted expressions.  This happened to not matter because only regex and numeric literals were supported; however it is not fully general and it was simple enough to properly compile (and therefore evaluate) function arguments at query evaluation time (see the change in `compile.rs`).