### PR TITLE
Add a flag (`--jsonl`) to emit matches in JSONL format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
 name = "knuffel"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +679,7 @@ dependencies = [
  "pretty",
  "regex",
  "serde",
+ "serde_json",
  "test-generator",
  "thiserror",
  "toml",
@@ -755,6 +762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +794,17 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ num_cpus = "^1"
 once_cell = "^1.16"
 pretty = "^0.11"
 regex = "^1"
+serde = { version = "^1", features = ["derive"] }
+serde_json = "^1"
 tracing = "^0.1"
 tracing-subscriber = { version = "^0.3", features = ["env-filter"]}
 thiserror = "^1"
@@ -37,7 +39,6 @@ tree-sitter-java = "^0.20"
 cc="^1.0"
 
 [dev-dependencies]
-serde = { version = "^1", features = ["derive"] }
 test-generator = "^0.3"
 # Used to specify the expected formats of tests (see [ref:toml-test-cases])
 toml = "^0.5"

--- a/src/bin/qg/cli.rs
+++ b/src/bin/qg/cli.rs
@@ -39,4 +39,6 @@ pub struct Cli {
     pub print_manpage: bool,
     #[arg(long, help = "Print shell completions and exit")]
     pub print_shell_completions: Option<clap_complete::Shell>,
+    #[arg(long, help = "Print matches in JSONL format")]
+    pub jsonl: bool,
 }

--- a/src/bin/qg/jsonl.rs
+++ b/src/bin/qg/jsonl.rs
@@ -1,0 +1,59 @@
+/// Support for generating jsonl (line-delimited JSON) output
+use ql_grep::{QueryResult, SourceFile};
+use std::path::Path;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Location<'a> {
+    source_file: &'a Path,
+    start_row: usize,
+    start_col: usize,
+    end_row: usize,
+    end_col: usize,
+}
+
+#[derive(Serialize)]
+pub enum OutputValue<'a> {
+    MatchedEntity {
+        location: Location<'a>,
+        matched_object: &'a str,
+    },
+    DecodeError {
+        location: Location<'a>,
+    },
+    MatchedConstant {
+        value: String,
+    },
+}
+
+impl <'a> OutputValue<'a> {
+    pub fn new(source_file: &'a SourceFile, result: &'a QueryResult) -> OutputValue<'a> {
+        match result {
+            QueryResult::Constant(c) => OutputValue::MatchedConstant { value: c.to_string() },
+            QueryResult::Node(rng, _highlights) => {
+                // FIXME: Could capture highlights in this as a list
+                let loc = Location {
+                    source_file: source_file.file_path.as_path(),
+                    start_row: rng.start_point.row,
+                    start_col: rng.start_point.column,
+                    end_row: rng.end_point.row,
+                    end_col: rng.end_point.column,
+                };
+                let all_bytes = source_file.source.as_bytes();
+                let slice = &all_bytes[rng.start_byte .. rng.end_byte];
+                match std::str::from_utf8(slice) {
+                    Ok(s) => OutputValue::MatchedEntity {
+                        location: loc,
+                        matched_object: s,
+                    },
+                    Err(_) => OutputValue::DecodeError { location: loc }
+                }
+            }
+        }
+    }
+
+    pub fn to_string(&self) -> anyhow::Result<String> {
+        let json = serde_json::to_string(self)?;
+        Ok(json)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::compile::interface::TreeInterface;
 pub use crate::evaluate::{evaluate_plan, QueryResult};
 pub use crate::library::LIBRARY_DATA;
 pub use crate::plan::{plan_query, QueryPlan};
-pub use crate::query::ir::{Select, Syntax, Typed};
+pub use crate::query::ir::{Constant, Select, Syntax, Typed};
 pub use crate::query::parse_query;
 pub use crate::query::typecheck::{typecheck_query, TypedQuery};
 pub use crate::source_file::{SourceError, SourceFile};


### PR DESCRIPTION
The JSONL format is the "line-oriented" JSON format with one object per line of output.  This is meant to be a machine readable version of the output.